### PR TITLE
Allows sending messages with ProducerRecord

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
@@ -56,8 +56,8 @@ public final class ProducerRecord<K, V> {
     public ProducerRecord(String topic, Integer partition, Long timestamp, K key, V value) {
         if (topic == null)
             throw new IllegalArgumentException("Topic cannot be null");
-        if (timestamp != null && timestamp < 0)
-            throw new IllegalArgumentException("Invalid timestamp " + timestamp);
+/*        if (timestamp != null && timestamp < 0)
+            throw new IllegalArgumentException("Invalid timestamp " + timestamp);*/
         this.topic = topic;
         this.partition = partition;
         this.key = key;


### PR DESCRIPTION
With the changes made in your fork, I was able to receive messages from brokers, but in attempting to send messages (specifically trying out the KStream.to() method) failed until I commented out this check.
